### PR TITLE
Fix JSON quoting in Lua sender

### DIFF
--- a/scripts/send-to-bot.lua
+++ b/scripts/send-to-bot.lua
@@ -14,27 +14,31 @@ function otr_hook(topic, _type, data)
 		return str
 	end
 
-	local json = '{' ..
-			'"latitude":"'  .. escape_json(data['lat']) .. '",' ..
-			'"longitude":"' .. escape_json(data['lon']) .. '",' ..
-			'"timezone":"'  .. escape_json(data['tzname']) .. '",' ..
-			'"country":"'   .. escape_json(data['cc']) .. '",' ..
-			'"alt":"'       .. escape_json(data['alt']) .. '",' ..
-			'"batt":"'      .. escape_json(data['batt']) .. '",' ..
-			'"acc":"'       .. escape_json(data['acc']) .. '",' ..
-			'"vac":"'       .. escape_json(data['vac']) .. '",' ..
-			'"conn":"'      .. escape_json(data['conn']) .. '",' ..
-			'"locality":"'  .. escape_json(data['locality']) .. '",' ..
-			'"ghash":"'     .. escape_json(data['ghash']) .. '",' ..
-			'"p":"'         .. escape_json(data['p']) .. '",' ..
-			'"addr":"'      .. escape_json(data['addr']) .. '"' ..
-			'}'
+        local json = '{' ..
+                        '"latitude":"'  .. escape_json(data['lat']) .. '",' ..
+                        '"longitude":"' .. escape_json(data['lon']) .. '",' ..
+                        '"timezone":"'  .. escape_json(data['tzname']) .. '",' ..
+                        '"country":"'   .. escape_json(data['cc']) .. '",' ..
+                        '"alt":"'       .. escape_json(data['alt']) .. '",' ..
+                        '"batt":"'      .. escape_json(data['batt']) .. '",' ..
+                        '"acc":"'       .. escape_json(data['acc']) .. '",' ..
+                        '"vac":"'       .. escape_json(data['vac']) .. '",' ..
+                        '"conn":"'      .. escape_json(data['conn']) .. '",' ..
+                        '"locality":"'  .. escape_json(data['locality']) .. '",' ..
+                        '"ghash":"'     .. escape_json(data['ghash']) .. '",' ..
+                        '"p":"'         .. escape_json(data['p']) .. '",' ..
+                        '"addr":"'      .. escape_json(data['addr']) .. '"' ..
+                        '}'
+
+        -- Escape single quotes so the JSON can be safely wrapped in single
+        -- quotes when passed to the shell command below.
+        local json_escaped = json:gsub("'", "'\\''")
 
 	otr.log("Sending data as JSON:")
 	otr.log("Payload: " .. json)
 
 	local url = "http://10.168.0.77:7890/location"
-	local cmd = 'curl -X POST -s "' .. url .. '" -H "Content-Type: application/json" -d \'' .. json .. '\' 2>&1'
+        local cmd = 'curl -X POST -s "' .. url .. '" -H "Content-Type: application/json" -d \'' .. json_escaped .. '\' 2>&1'
 	otr.log("Executing command: " .. cmd)
 
 	local handle = io.popen(cmd)


### PR DESCRIPTION
## Summary
- escape single quotes in JSON payload in `send-to-bot.lua`
- use the escaped JSON when invoking `curl`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68583efcd63483259226faf20619cbd8