### PR TITLE
Add logging of data keys in Lua script

### DIFF
--- a/scripts/send-to-bot.lua
+++ b/scripts/send-to-bot.lua
@@ -2,6 +2,15 @@ function otr_init()
 end
 
 function otr_hook(topic, _type, data)
+        -- Log all keys available in the data table
+        if data ~= nil then
+                for key, _ in pairs(data) do
+                        otr.log("data key: " .. tostring(key))
+                end
+        else
+                otr.log("data is nil")
+        end
+
         -- Escapes string values for JSON
         local function escape_json(str)
                 if str == nil then return "" end


### PR DESCRIPTION
## Summary
- log all key names present in `data` to otr.log in the Lua script

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685e323115ac83259b2b2f432b2dd179