### PR TITLE
Add BSSID and SSID fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ CREATE TABLE country_days_tracker_bot.country_days_tracker (
     locality String,
     ghash String,
     p Float64,
-    addr String
+    addr String,
+    bssid LowCardinality(Nullable(String)),
+    ssid LowCardinality(Nullable(String)),
+    bs Nullable(UInt32)
 ) ENGINE = MergeTree()
 ORDER BY (user_id, date_time);
 ```

--- a/scripts/send-to-bot.lua
+++ b/scripts/send-to-bot.lua
@@ -43,7 +43,10 @@ function otr_hook(topic, _type, data)
                         '"locality":"'  .. escape_json(data['locality']) .. '",' ..
                         '"ghash":"'     .. escape_json(data['ghash']) .. '",' ..
                         '"p":'         .. escape_json_number(data['p']) .. ',' ..
-                        '"addr":"'      .. escape_json(data['addr']) .. '"' ..
+                        '"addr":"'      .. escape_json(data['addr']) .. '",' ..
+                        '"bssid":"'     .. escape_json(data['bssid']) .. '",' ..
+                        '"ssid":"'      .. escape_json(data['ssid']) .. '",' ..
+                        '"bs":'         .. escape_json_number(data['bs']) ..
                         '}'
 
         -- Escape single quotes so the JSON can be safely wrapped in single

--- a/src/main/kotlin/DatabaseService.kt
+++ b/src/main/kotlin/DatabaseService.kt
@@ -28,7 +28,10 @@ class DatabaseService {
         locality: String,
         ghash: String,
         p: Double,
-        addr: String
+        addr: String,
+        bssid: String?,
+        ssid: String?,
+        bs: Int?
     ) {
         sessionOf(dataSource).use { session ->
             session.execute(
@@ -49,7 +52,10 @@ class DatabaseService {
                             locality,
                             ghash,
                             p,
-                            addr
+                            addr,
+                            bssid,
+                            ssid,
+                            bs
                         )
                         SELECT
                             toDateTime(?) AS date_time,
@@ -65,7 +71,10 @@ class DatabaseService {
                             toString(?) AS locality,
                             toString(?) AS ghash,
                             toFloat64(?) AS p,
-                            toString(?) AS addr
+                            toString(?) AS addr,
+                            toString(?) AS bssid,
+                            toString(?) AS ssid,
+                            toUInt32(?) AS bs
                     """.trimIndent(),
                     dateTime,
                     latitude,
@@ -80,7 +89,10 @@ class DatabaseService {
                     locality,
                     ghash,
                     p,
-                    addr
+                    addr,
+                    bssid,
+                    ssid,
+                    bs
                 )
 
             )

--- a/src/main/kotlin/WebService.kt
+++ b/src/main/kotlin/WebService.kt
@@ -30,7 +30,10 @@ data class LocationRequest(
     val locality: String,
     val ghash: String,
     val p: Double,
-    val addr: String
+    val addr: String,
+    val bssid: String? = null,
+    val ssid: String? = null,
+    val bs: Int? = null
 )
 
 class WebService(private val databaseService: DatabaseService) {
@@ -72,24 +75,27 @@ class WebService(private val databaseService: DatabaseService) {
                 return
             }
 
-            databaseService.save(
-                Instant.ofEpochSecond(body.timestamp)
-                    .atZone(body.timezone.toTimeZone())
-                    .toLocalDateTime(),
-                body.latitude,
-                body.longitude,
-                body.timezone.toTimeZone(),
-                body.country.toCountry(),
-                body.alt,
-                body.batt,
-                body.acc,
-                body.vac,
-                body.conn,
-                body.locality,
-                body.ghash,
-                body.p,
-                body.addr
-            )
+                databaseService.save(
+                    Instant.ofEpochSecond(body.timestamp)
+                        .atZone(body.timezone.toTimeZone())
+                        .toLocalDateTime(),
+                    body.latitude,
+                    body.longitude,
+                    body.timezone.toTimeZone(),
+                    body.country.toCountry(),
+                    body.alt,
+                    body.batt,
+                    body.acc,
+                    body.vac,
+                    body.conn,
+                    body.locality,
+                    body.ghash,
+                    body.p,
+                    body.addr,
+                    body.bssid,
+                    body.ssid,
+                    body.bs
+                )
         }.onSuccess {
             KSLog.info("Successfully saved location update")
             call.respond(HttpStatusCode.OK)


### PR DESCRIPTION
## Summary
- allow LocationRequest to accept optional wifi fields
- persist wifi details in the database
- forward wifi fields from WebService to DatabaseService
- extend OwnTracks hook to send wifi fields
- document new columns in database schema

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685e3734b00c8325ab07d6b0ac453ec7