### PR TITLE
Add city statistics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Telegram bot that tracks the countries you've visited and provides statistics 
 - Track countries visited based on location data
 - View statistics about your travels, including:
   - List of visited countries with days spent in each
+  - List of visited cities with days spent in each
   - Percentage of world countries visited
   - Current country and length of stay
 - Converts time spent in countries to a human-readable format (years, months, weeks, days)

--- a/src/main/kotlin/DatabaseService.kt
+++ b/src/main/kotlin/DatabaseService.kt
@@ -123,6 +123,29 @@ class DatabaseService {
             )
     }
 
+    fun getCityStats(): List<Pair<String, Int>> {
+        return sessionOf(dataSource)
+            .run(
+                queryOf(
+                    // language=SQL
+                    """
+                        SELECT locality, COUNT(*) AS count_of_days
+                        FROM (
+                            SELECT DISTINCT LOWER(locality) AS locality, toStartOfDay(date_time)
+                            FROM country_days_tracker_bot.country_days_tracker
+                        )
+                        GROUP BY locality
+                        ORDER BY COUNT(*) DESC
+                    """.trimIndent(),
+                    mapOf(),
+                )
+                    .map { row ->
+                        Pair(row.string("locality"), row.int("count_of_days"))
+                    }
+                    .asList
+            )
+    }
+
     fun getCurrentCountryLength(): Pair<String, Int> {
         return sessionOf(dataSource)
             .run(

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -23,18 +23,34 @@ suspend fun main() {
     webService.start(80)
     longPolling({ restrictAccess(EnvironmentVariableUserAccessChecker()) }) {
             setMyCommands(
-                BotCommand("stat", "show statistics")
+                BotCommand("stat", "show statistics"),
+                BotCommand("citystat", "show city statistics")
             )
             onCommand("stat") {
                 val i = AtomicInteger(1)
 
                 val stat = dbService.getCountryStats()
                 val msg = buildString {
-                    append(stat.joinToString("\n") { "${i.getAndIncrement()} - ${it.first} - ${it.second}(${prettyTime(it.second)})" })
+                    append(
+                        stat.joinToString("\n") {
+                            "${i.getAndIncrement()} - ${it.first} - ${it.second}(${prettyTime(it.second)})"
+                        }
+                    )
                     append("\n\n")
                     append(calculateVisitedPercentage(stat.size) + "\n")
                     val currentCountry = dbService.getCurrentCountryLength()
                     append("Current country: ${currentCountry.first} ${currentCountry.second}")
+                }
+
+                KSLog.info(stat)
+                reply(it, msg)
+            }
+            onCommand("citystat") {
+                val i = AtomicInteger(1)
+
+                val stat = dbService.getCityStats()
+                val msg = stat.joinToString("\n") {
+                    "${i.getAndIncrement()} - ${it.first} - ${it.second}(${prettyTime(it.second)})"
                 }
 
                 KSLog.info(stat)


### PR DESCRIPTION
## Summary
- support gathering city statistics in the database layer
- add `/citystat` command to show days spent in each city
- document city statistics feature in README

## Testing
- `./gradlew build` *(fails: dependency requires JVM runtime version 24 or newer)*

------
https://chatgpt.com/codex/tasks/task_e_688f414fc2a08325ba88ec1d7d8cbeec