### PR TITLE
Store empty-country updates but exclude from stats

### DIFF
--- a/src/main/kotlin/DatabaseService.kt
+++ b/src/main/kotlin/DatabaseService.kt
@@ -110,6 +110,7 @@ class DatabaseService {
                         FROM (
                             SELECT DISTINCT LOWER(country) AS country, toStartOfDay(date_time)
                             FROM country_days_tracker_bot.country_days_tracker
+                            WHERE country != ''
                         )
                         GROUP BY country
                         ORDER BY COUNT(*) DESC
@@ -159,6 +160,7 @@ class DatabaseService {
                                     toDate(date_time) AS day,
                                     country
                                 FROM country_days_tracker_bot.country_days_tracker
+                                WHERE country != ''
                                 GROUP BY day, country
                             ),
                             with_sessions AS (

--- a/src/main/kotlin/WebService.kt
+++ b/src/main/kotlin/WebService.kt
@@ -75,7 +75,7 @@ class WebService(private val databaseService: DatabaseService) {
                 return
             }
 
-                databaseService.save(
+            databaseService.save(
                     Instant.ofEpochSecond(body.timestamp)
                         .atZone(body.timezone.toTimeZone())
                         .toLocalDateTime(),


### PR DESCRIPTION
## Summary
- save location updates even when country is blank
- filter out empty-country records in country stats and current-country calculations

## Testing
- `./gradlew test` *(fails: dependency requires JDK 24)*
- `apt-get install -y openjdk-24-jdk` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689efa1b4a148325b3c07f0e44b637d8