### PR TITLE
Avoid empty period parentheses

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -33,7 +33,9 @@ suspend fun main() {
                 val msg = buildString {
                     append(
                         stat.joinToString("\n") {
-                            "${i.getAndIncrement()} - ${it.first} - ${it.second}(${prettyTime(it.second)})"
+                            val pretty = prettyTime(it.second)
+                            val period = if (pretty.isEmpty()) "" else "($pretty)"
+                            "${i.getAndIncrement()} - ${it.first} - ${it.second}$period"
                         }
                     )
                     append("\n\n")
@@ -50,7 +52,9 @@ suspend fun main() {
 
                 val stat = dbService.getCityStats()
                 val msg = stat.joinToString("\n") {
-                    "${i.getAndIncrement()} - ${it.first} - ${it.second}(${prettyTime(it.second)})"
+                    val pretty = prettyTime(it.second)
+                    val period = if (pretty.isEmpty()) "" else "($pretty)"
+                    "${i.getAndIncrement()} - ${it.first} - ${it.second}$period"
                 }
 
                 KSLog.info(stat)


### PR DESCRIPTION
## Summary
- Avoid adding parentheses when pretty time is empty

## Testing
- `./gradlew build` *(fails: Could not resolve com.github.centralhardware:ktgbotapi-commons:28.0.0, dependency requires JVM 24 or newer)*

------
https://chatgpt.com/codex/tasks/task_e_689f03ce1fd083258d1b22c5cf110f4c